### PR TITLE
Responsive YouTube embeds with max width on desktops

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -51,6 +51,10 @@ img {
     height: auto;
 }
 
+.embed-responsive {
+    max-width: 800px;
+}
+
 .footnote {
 	text-align: center;
 }

--- a/source/items/buildingtool.md
+++ b/source/items/buildingtool.md
@@ -4,16 +4,17 @@ layout: default
 ---
 # Building Tool
 <div class="infobox box text-center">
-    <hr />
     <recipe>buildingtool</recipe>
-    <hr />
 </div>
 <br>
 Welcome to the Building Tool page. Crafting the building tool is simple and it is *THE* most important tool you will need for the entire mod. With the building tool you can place the Supply Ship or Supply Camp, all the buildings, worker huts and even even any structure scanned by you (see [Schematics](../tutorials/schematics)) in the perfect way. The possibilitites are endless! Watch a short video of how it works here:
 <br><br>
-<p style="text-align:center; font-size:20pt;"><b><a name="build_tool">Building Tool Video.</a></b></p>
 
-<p style="text-align:center;"><embed width="560" height="340" src="https://www.youtube.com/embed/DVGGDUXbTOY" frameborder="10" allow="autoplay; encrypted-media" allowfullscreen></p>
+<p class="h4"><a name="build_tool">Building Tool Video.</a></p>
+
+<div class="embed-responsive embed-responsive-16by9">
+  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DVGGDUXbTOY" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</div>
 <br>
 
 ### Step One

--- a/source/items/scantool.md
+++ b/source/items/scantool.md
@@ -4,16 +4,16 @@ layout: default
 ---
 # Scan Tool
 <div class="infobox box text-center">
-    <hr />
     <recipe>scantool</recipe>
-    <hr />
 </div>
 <br>
 Welcome to the Scan Tool page. Crafting the scan tool is simple and it is a very very useful tool. With the scan tool you can scan any structure you like and Have the builder build it for you. So find if you a building, house, walls, bridges, towers, shops or any structure that you want in your Town, you can build it in creative or paste it with world edit (f.e.) and then scan it. You can scan a structure in Singleplayer or Multiplayer (even on a server). The scanned structure will be in a schematic file that you can then use the build tool to place and have your Builder build it for you ([Schematics](../tutorials/schematics) Page for more info). Want your builder to clear an area for you (and level up while working.. of course) then scan an area of "air" and place it with the building tool over what you want the builder to clear and watch him clear that area away leaving only "air" in it's place! The possibilities are endless! Watch a short video of how it works here:
 
-**Scan Tool Video**
+<p class="h4">Scan Tool Video</p>
 
-<p style="text-align:center;"><embed width="560" height="340" src="https://www.youtube.com/embed/mFIC3752o1c" frameborder="10" allow="autoplay; encrypted-media" allowfullscreen></p>
+<div class="embed-responsive embed-responsive-16by9">
+  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/mFIC3752o1c" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</div>
 <br>
 
 ### Step One

--- a/source/tutorials/tutorial.md
+++ b/source/tutorials/tutorial.md
@@ -18,7 +18,7 @@ layout: default
     - [Step 3](#step-3)
     - [Step 4](#step-4)
     - [Final Notes](#final-notes)
-{: .box .py-3 .pr-4 }   
+{: .box .py-3 .pr-4 }
 
 If you'd like instructions on how to <a name="install">install</a> our [Official Mod Pack](https://minecraft.curseforge.com/projects/minecolonies) we have two options; instructions for the Twitch Launcher click [here](../installation/twitch) (Previously Curse launcher) or for MultiMC click [here](../installation/multimc). If you just want to install our Mod in the original Minecraft Launcher click [here](../installation/java).
 
@@ -32,7 +32,7 @@ But one of the first questions you should ask yourself is: "*Where should I put 
 
 <p style="text-align:center; font-size:20pt;"><b><a name="build_tool">Building Tool Video.</a></b></p>
 
-<div class="embed-responsive embed-responsive-16by9 center">
+<div class="embed-responsive embed-responsive-16by9 mx-auto">
   <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DVGGDUXbTOY" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
 <br />
@@ -63,7 +63,7 @@ So, the first thing you want to do is find the perfect spot to settle down. But,
 
 <p style="text-align:center; font-size:20pt;"><b><a name="build_tool">Build Tool Video.</a></b></p>
 
-<div class="embed-responsive embed-responsive-16by9 center">
+<div class="embed-responsive embed-responsive-16by9 mx-auto">
   <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DVGGDUXbTOY" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
 <br />

--- a/source/tutorials/tutorial.md
+++ b/source/tutorials/tutorial.md
@@ -30,7 +30,7 @@ But one of the first questions you should ask yourself is: "*Where should I put 
 
 **Hint:** The most important tool you will need for the entire mod is the Building Tool (check out our [Building Tool](../items/buildingtool) page). Craft the Building Tool so you can place all the buildings, worker huts and even the Supply Ship or Supply Camp in the perfect spot. 
 
-<p style="text-align:center; font-size:20pt;"><b><a name="build_tool">Building Tool Video.</a></b></p>
+<p class="h4 mx-auto"><b><a name="build_tool">Building Tool Video.</a></b></p>
 
 <div class="embed-responsive embed-responsive-16by9 mx-auto">
   <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DVGGDUXbTOY" allow="autoplay; encrypted-media" allowfullscreen></iframe>
@@ -61,7 +61,7 @@ So, the first thing you want to do is find the perfect spot to settle down. But,
 
 **Hint:** The most important tool you will need for the entire mod is the Building Tool (check out our [Building Tool](../items/buildingtool) page). Craft the Building Tool so you can place all the buildings, worker huts and even the Supply Ship or Supply Camp in the perfect spot.
 
-<p style="text-align:center; font-size:20pt;"><b><a name="build_tool">Build Tool Video.</a></b></p>
+<p class="h4 mx-auto"><b><a name="build_tool">Build Tool Video.</a></b></p>
 
 <div class="embed-responsive embed-responsive-16by9 mx-auto">
   <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DVGGDUXbTOY" allow="autoplay; encrypted-media" allowfullscreen></iframe>


### PR DESCRIPTION
- Makes YouTube videos responsive to screen size, whilst having a max width on desktop so they aren't too large. 
- Left aligns the video/video header text on the scan tool and building tool page for a better look (with the infobox on these pages, the center alignment is thrown off)
- Adding h4 classes to headers above videos (Gives the styling of H4 elements without the use of this element) keeps the text large as intended but simply through classes instead of inline styling