### PR TITLE
fix markdown rendering on schematics page

### DIFF
--- a/source/tutorials/schematics.md
+++ b/source/tutorials/schematics.md
@@ -187,8 +187,7 @@ Here is a full list, up-to-date as of 9 February 2020, of the building names. **
 <ul>
   <li>Use unobtainable items in builds (no command blocks, petrified wood, infested blocks, or mob heads (including player heads))</li>
   <li>Change someone else's style (officially) unless specifically asked to do so</li>
-
-<br>
+</ul>
 
 ## Additional Information
 


### PR DESCRIPTION
ideally this should all be in markdown, but I just closed the `ul` tag and removed the unnecessary `br` tag to fix this.

this is what it [currently looks like](https://ldtteam.github.io/MinecoloniesWiki/source/tutorials/schematics):

![image](https://user-images.githubusercontent.com/924465/87217338-f8cdb780-c2fc-11ea-900c-0604237813f4.png)
