### PR TITLE
Add note about miner's interaction with level GUI

### DIFF
--- a/source/buildings/mine.md
+++ b/source/buildings/mine.md
@@ -49,7 +49,7 @@ This is page two of the Mine's GUI.
   </div>
   <div class="col-sm-12 col-md">
     <ul>
-      <li><strong>Levels:</strong> The level refers to the platforms the Miner will place every 3 blocks down. Here you can assign what level of the Mine the Miner will create their mineshafts (nodes). If a level has a red number next to it, that means the Miner is currently mining that level.</li><br>
+      <li><strong>Levels:</strong> The level refers to the platforms the Miner will place every 3 blocks down. Here you can assign what level of the Mine the Miner will create their mineshafts (nodes). If a level has a red number next to it, that means the Miner is currently mining that level. The miner will ignore orders to mine at specified levels until the entire mine shaft is completed to the maximum depth their level allows.</li><br>
     </ul>
   </div>
 </div>  

--- a/source/buildings/mine.md
+++ b/source/buildings/mine.md
@@ -49,7 +49,7 @@ This is page two of the Mine's GUI.
   </div>
   <div class="col-sm-12 col-md">
     <ul>
-      <li><strong>Levels:</strong> The level refers to the platforms the Miner will place every 3 blocks down. Here you can assign what level of the Mine the Miner will create their mineshafts (nodes). If a level has a red number next to it, that means the Miner is currently mining that level. The miner will ignore orders to mine at specified levels until the entire mine shaft is completed to the maximum depth their level allows.</li><br>
+      <li><strong>Levels:</strong> The level refers to the platforms the Miner will place every 3 blocks down. Here you can assign what level of the Mine the Miner will create their mineshafts (nodes). If a level has a red number next to it, that means the Miner is currently mining that level. The Miner will ignore orders to mine at a specified level until the entire mineshaft is completed to the maximum depth their hut's level allows.</li><br>
     </ul>
   </div>
 </div>  


### PR DESCRIPTION
This is just a message to clarify the behavior of the miner's interaction with this GUI. I was unable to find an explanation for why the miner was ignoring my command to mine at a specified level and instead kept leveling the miner's hut further increasing his workload for building the shaft. I finally read through the source code just to figure it out. I would really recommend making a change to the GUI to reflect that no action will be taken until the mine shaft is completed. That level of feedback would be welcome to newcomers like me who believed the miner's failure to produce resources ruined the entire mod's balance. This message here is just a quick solution in my opinion. **The wordage can be changed, but I urge the maintainers to include this note.**