### PR TITLE
Paper fix

### DIFF
--- a/assets/data/recipes/timberframeplain.json
+++ b/assets/data/recipes/timberframeplain.json
@@ -9,7 +9,7 @@
       "secondRow":
       {
         "firstItem": "",
-        "secondItem": ["minecraft/paper","minecraft/paper", "minecraft/paper","minecraft/paper","minecraft/paper","minecraft/paper", "minecolonies/paper"],
+        "secondItem": "minecraft/paper",
         "thirdItem": ""
       },
       "thirdRow":


### PR DESCRIPTION
Closes #

## Changes proposed:
- Fixes the `["minecraft:paper", "minecraft:paper",` etc shown in #526 
- 

Merge please :D
