### PR TITLE
Pathblocks

### DIFF
--- a/source/misc/troubleshooting.md
+++ b/source/misc/troubleshooting.md
@@ -64,3 +64,13 @@ If none of these apply, go on to the next troubleshooting checklists.
   12. Use the /mc colony requestsystem-reset [command](../../source/systems/command).
   13. Repair their work hut. Some workers will stop working if required elements are not present. Only the [Builder](../../source/workers/builder) can place beds, crafting tables, furnaces, chests, [racks](../../source/items/rack), and [compost barrels](../../source/items/compostbarrel). If you broke any of those, create a repair build order for the building.
   14. Fire worker, wait a few minutes, then hire a different worker (you will lose advantage of the experience the first worker had accumulated at this career).
+
+## Upgrading to a newer Minecraft version
+Minecolonies is _not_ compatible in between major Minecraft versions. Upgrading a 1.16.5 modded world with Minecolonies to 1.18.1 won't work and is not supported at all.
+
+This is because mods tend to make breaking changes in between major Minecraft versions.
+
+An example to what can happen when you try to upgrade a world between major versions, to illustrate why it is a bad idea:
+  1. Shingles and timber frames got moved to Domum Ornamentum. Therefore, shingle and timber frame blocks will be gone from the world during the upgrade.
+  2. There is a bug that prevents modded block entities from retaining their data, which would mean that any hut block would lose the building they are connected to,
+     and any Domum Ornamentum block would fall back to their standard textures, or simply be removed.

--- a/source/systems/pathing.md
+++ b/source/systems/pathing.md
@@ -20,7 +20,7 @@ This does take a while, though, and sometimes can result in unforeseen circumsta
 
 ## Pathblocks
 
-On certain [pathblocks](https://github.com/ldtteam/minecolonies/blob/version/main/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json), your colonists move faster and stick to the paths when pathfinding. Building roads out of these can help keep them on a safe path and get them around the colony faster.
+On certain pathblocks (in [1.16.5](https://github.com/ldtteam/minecolonies/blob/version/main/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json) and [1.18.1](https://github.com/ldtteam/minecolonies/blob/version/1.18/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json)), your colonists move faster and stick to the paths when pathfinding. Building roads out of these can help keep them on a safe path and get them around the colony faster.
 
 ## Waypoints and Decorative Paths
 

--- a/source/systems/pathing.md
+++ b/source/systems/pathing.md
@@ -20,7 +20,7 @@ This does take a while, though, and sometimes can result in unforeseen circumsta
 
 ## Pathblocks
 
-On certain pathblocks (in 1.16.5 [[link]](https://github.com/ldtteam/minecolonies/blob/version/main/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json) and 1.18.1 [[link]](https://github.com/ldtteam/minecolonies/blob/version/1.18/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json)), your colonists move faster and stick to the paths when pathfinding. Building roads out of these can help keep them on a safe path and get them around the colony faster.
+On certain pathblocks (in 1.16.5 [[list]](https://github.com/ldtteam/minecolonies/blob/version/main/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json) and 1.18.1 [[list]](https://github.com/ldtteam/minecolonies/blob/version/1.18/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json)), your colonists move faster and stick to the paths when pathfinding. Building roads out of these can help keep them on a safe path and get them around the colony faster.
 
 ## Waypoints and Decorative Paths
 

--- a/source/systems/pathing.md
+++ b/source/systems/pathing.md
@@ -20,7 +20,7 @@ This does take a while, though, and sometimes can result in unforeseen circumsta
 
 ## Pathblocks
 
-On certain pathblocks (in [1.16.5](https://github.com/ldtteam/minecolonies/blob/version/main/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json) and [1.18.1](https://github.com/ldtteam/minecolonies/blob/version/1.18/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json)), your colonists move faster and stick to the paths when pathfinding. Building roads out of these can help keep them on a safe path and get them around the colony faster.
+On certain pathblocks (in 1.16.5 [[link]](https://github.com/ldtteam/minecolonies/blob/version/main/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json) and 1.18.1 [[link]](https://github.com/ldtteam/minecolonies/blob/version/1.18/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json)), your colonists move faster and stick to the paths when pathfinding. Building roads out of these can help keep them on a safe path and get them around the colony faster.
 
 ## Waypoints and Decorative Paths
 


### PR DESCRIPTION
## Changes proposed:
- Adds a link to the 1.18 pathblocks list on the pathing system page
- I changed it to `On certain pathblocks (in 1.16.5 [list] and 1.18.1 [list])`, where `[list]` is a link to the 1.16.5 path blocks respectively 1.18.1 path blocks.
  I also considered for the 1.16.5 and 1.18.1 being links themselves, having something like `pathblocks (in 1.16.5 and 1.18.1)`, but I felt like there was missing something. Hence the addition of [list]

Merge please :D
