### PR TITLE
Fix the old message saying that you need various blocks under the sand

### DIFF
--- a/source/tutorials/schematics.md
+++ b/source/tutorials/schematics.md
@@ -164,7 +164,7 @@ So, for example, the path would be `structurize/schematics/wildwest/builder1` fo
 | [House](../../source/buildings/house)                   | 1 bed per level                                                      |                     |
 | [Library](../../source/buildings/library)               | Bookshelves                                                          |                     |
 | [Mine](../../source/buildings/mine)                     | A few starting ladders where the shaft's ladders will go             |                     |
-| [Plantation](../../source/buildings/plantation)         | 12 (3 x 4) per level, for sugar cane, cactus and bamboo              |                     |
+| [Plantation](../../source/buildings/plantation)         | 12 per level, 4 for each of sugar cane, cactus and bamboo            |                     |
 | [Restaurant](../../source/buildings/restaurant)         | 1 furnace per level                                                  |                     |
 | [School](../../source/buildings/school)                 | 2 carpets per level                                                  | 4 carpets per level |
 | [Smeltery](../../source/buildings/school)               | 1 furnace per level                                                  |                     |

--- a/source/tutorials/schematics.md
+++ b/source/tutorials/schematics.md
@@ -164,7 +164,7 @@ So, for example, the path would be `structurize/schematics/wildwest/builder1` fo
 | [House](../../source/buildings/house)                   | 1 bed per level                                                      |                     |
 | [Library](../../source/buildings/library)               | Bookshelves                                                          |                     |
 | [Mine](../../source/buildings/mine)                     | A few starting ladders where the shaft's ladders will go             |                     |
-| [Plantation](../../source/buildings/plantation)         | 4 per level: brick under sand, cobble under sand, sand next to water |                     |
+| [Plantation](../../source/buildings/plantation)         | 12 (3 x 4) per level, for sugar cane, cactus and bamboo              |                     |
 | [Restaurant](../../source/buildings/restaurant)         | 1 furnace per level                                                  |                     |
 | [School](../../source/buildings/school)                 | 2 carpets per level                                                  | 4 carpets per level |
 | [Smeltery](../../source/buildings/school)               | 1 furnace per level                                                  |                     |


### PR DESCRIPTION
## Changes proposed:
- Update the information on the tutorial/schematics page so that it doesn't show the old way of placing sand anymore. The tag tool is already mentioned below the table, hence I didn't include a note about the tag tool in the table as well

Merge please :D
