### PR TITLE
Modular setup for content pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
 .idea/
+.jekyll-cache

--- a/_data/buildingsettings.yml
+++ b/_data/buildingsettings.yml
@@ -1,0 +1,5 @@
+apiary:
+  - name: Breeding
+    description: On by default. Here you can choose if the Beekeeper will breed bees.
+  - name: Honeycombs or Honey
+    description: Here you choose if the Beekeeper will collect honeycombs, honey bottles, or both. They will collect whatever shows on the GUI.

--- a/_includes/contentblock/basic.html
+++ b/_includes/contentblock/basic.html
@@ -1,0 +1,13 @@
+<div class="row py-3">
+    {% if include.image | default "" != "" %}
+    <div class="col-sm-12 col-md">
+        <img src="{{ include.image }}" class="img-fluid mx-auto" alt="{{ include.alt | default: 'GUI' | strip }}">
+    </div>
+    {% endif %}
+    <div class="col-sm-12 col-md">
+        {% if include.header | default: "" | strip != "" %}
+        <p>{{ include.header | strip }}</p>
+        {% endif %}
+        <p>{{ include.content | strip }}</p>
+    </div>
+</div>

--- a/_includes/contentblock/main-gui.html
+++ b/_includes/contentblock/main-gui.html
@@ -1,0 +1,17 @@
+<div class="row py-3">
+    {% if include.image | default "" != "" %}
+    <div class="col-sm-12 col-md">
+        <img src="{{ include.image }}" class="img-fluid mx-auto" alt="{{ include.alt | default: 'Main GUI' | strip }}">
+    </div>
+    {% endif %}
+    <div class="col-sm-12 col-md">
+        {% if include.header | default: "" | strip != "" %}
+        <p>{{ include.header | strip }}</p>
+        {% endif %}
+        <ul>
+            {% for item in site.data.gui.global %}
+            <li><strong>{{ item.button }}:</strong> {{ item.content }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>

--- a/_includes/contentblock/settings-gui.html
+++ b/_includes/contentblock/settings-gui.html
@@ -1,0 +1,18 @@
+<div class="row py-3">
+    {% if include.image | default "" != "" %}
+    <div class="col-sm-12 col-md">
+        <img src="{{ include.image }}" class="img-fluid mx-auto" alt="{{ include.alt | default: 'Building settings GUI' | strip
+            }}">
+    </div>
+    {% endif %}
+    <div class="col-sm-12 col-md">
+        {% if include.header | default: "" | strip != "" %}
+        <p>{{ include.header | strip }}</p>
+        {% endif %}
+        <ul>
+            {% for setting in site.data.buildingsettings[include.settingskey] %}
+            <li><strong>{{ setting.name }}:</strong> {{ setting.description }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>

--- a/_includes/contentblock/stock-gui.html
+++ b/_includes/contentblock/stock-gui.html
@@ -1,0 +1,15 @@
+<div class="row py-3">
+    <div class="col-sm-12 col-md">
+        <img src="../../assets/images/gui/minstockgui.png" class="img-fluid mx-auto" alt="Minimum stock GUI">
+    </div>
+    <div class="col-sm-12 col-md">
+        {% if include.header | default: "" | strip != "" %}
+        <p>{{ include.header | strip }}</p>
+        {% endif %}
+        <ul>
+            <li><strong> Minimum Stock: </strong> Use this button to tell the {{ include.buildingname | default:
+                "building" }} to keep a minimum stock on hand.
+                Set items will be displayed above the button.</li>
+        </ul>
+    </div>
+</div>

--- a/_includes/infobox.html
+++ b/_includes/infobox.html
@@ -1,0 +1,11 @@
+<div class="infobox box text-center">
+    <img src="{{ include.image }}" alt="{{ include.alt }}" />
+    <hr />
+    <div class="row section-text text-left">
+        {{ include.content }}
+    </div>
+    {% if include.recipe | default "" != "" %}
+    <hr />
+    <recipe>{{ include.recipe }}</recipe>
+    {% endif %}
+</div>

--- a/source/buildings/apiary.md
+++ b/source/buildings/apiary.md
@@ -4,111 +4,48 @@ layout: default
 ---
 # Apiary
 
-<div class="infobox box text-center">
-    <img src="../../assets/images/buildings/apiary.png" alt="Apiary" />
-    <hr />
-    <div class="row section-text text-left">
-        <div class="col">
-        <p><strong>Worker:</strong></p>
-        </div>
-        <div class="col">
-        <p><a href="../workers/beekeeper">Beekeeper</a></p>
-        </div>
-    </div>
-    <hr />
-    <recipe>apiary</recipe>
+{% capture infobox-content %}
+<div class="col">
+  <p><strong>Worker:</strong></p>
 </div>
+<div class="col">
+  <p><a href="../workers/beekeeper">Beekeeper</a></p>
+</div>
+{% endcapture %}
+{% include infobox.html content=infobox-content recipe="apiary" image="../../assets/images/buildings/apiary.png" alt="Apiary" %}
 
-The Apiary is where the Beekeeper works. The Beekeeper breeds bees and harvests honeycombs or honey bottles (you can choose which on the second page of the Apiary's GUI).
+The Apiary is where the Beekeeper works. The Beekeeper breeds bees and harvests honeycombs or honey bottles (you can
+choose which on the second page of the Apiary's GUI).
 
 The level of the Apiary determines the max number of hives the Beekeeper can take care of:
 
 | Apiary Level | Max Number of Hives |
 | ------------ | ------------------- |
-| 1 | 1 |
-| 2 | 2 |
-| 3 | 4 |
-| 4 | 8 |
-| 5 | 16 |
+| 1            | 1                   |
+| 2            | 2                   |
+| 3            | 4                   |
+| 4            | 8                   |
+| 5            | 16                  |
 
-**Note:** If the Beekeeper is asking for hives but there are some nearby, make sure you've set the hives for them to take care of with the hive tool. This tool is accessed from the second page of the Apiary GUI (see below).
+**Note:** If the Beekeeper is asking for hives but there are some nearby, make sure you've set the hives for them to
+take care of with the hive tool. This tool is accessed from the second page of the Apiary GUI (see below).
 
 ## Apiary GUI
 
 <div class="row">
- 
-<div class="col">
+  <div class="col">
+    When accessing the Apiary Hut block by right-clicking on it, you will see a GUI with different options. You start on
+    the main tab:
 
-When accessing the Apiary Hut block by right-clicking on it, you will see a GUI with different options. You start on the main tab:
+    {% include contentblock/main-gui.html image="../../assets/images/gui/apiarygui1.png" %}
 
-<br>
-<div class="row">
-  <div class="col-sm-12 col-md">
-    <img src="../../assets/images/gui/apiarygui1.png" class="img-fluid mx-auto" alt="Apiary GUI">
-  </div>
-  <div class="col-sm-12 col-md">
-    <br>
-    <ul>
-      {% for item in site.data.gui.global %}
-        <li><strong>{{ item.button }}:</strong> {{ item.content }}</li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
-<br>
+    {% include contentblock/stock-gui.html buildingname="Apiary" header="The second tab of the GUI is <strong>Minimum Stock</strong>. It has one button:" %}
 
-<br>
-<div class="row">
-  <div class="col-sm-12 col-md">
-    <img src="../../assets/images/gui/minstockgui.png" class="img-fluid mx-auto" alt="Apiary GUI 2">
-  </div>
-  <div class="col-sm-12 col-md">
-    <br>
-    <p>The second tab of the GUI is <strong>Minimum Stock</strong>.    It has one button:</p>
-    <ul>
-        <li><strong> Minimum Stock: </strong> Use this button to tell the Apiary to keep a minimum stock on hand. Set items will be displayed above the button.</li>
-    </ul>
-  </div>
-</div>
+    {% include contentblock/settings-gui.html settingskey="apiary" header="The third tab of the GUI is <strong>Settings</strong>. It has two buttons:" image="../../assets/images/gui/apiarygui3.png" %}
 
-<br>
-<div class="row">
-  <div class="col-sm-12 col-md">
-    <img src="../../assets/images/gui/apiarygui3.png" class="img-fluid mx-auto" alt="Apiary GUI 3">
-  </div>
-  <div class="col-sm-12 col-md">
-    <br>
-    <p>The third tab of the GUI is <strong>Settings</strong>.  It has two buttons:</p>
-    <ul>
-      <li><b>Breeding:</b> On by default. Here you can choose if the Beekeeper will breed bees.</li>
-      <li><b>Honeycombs or Honey:</b> Here you choose if the Beekeeper will collect honeycombs, honey bottles, or both. They will collect whatever shows on the GUI.</li>
-    </ul>
-  </div>
-</div>
+    {% include contentblock/basic.html header="The fourth tab of the GUI is <strong>Flowers</strong>." content="Here you designate what flowers you want the Beekeeper
+          to request and use during breeding. By default, all flowers are turned off." image="../../assets/images/gui/apiarygui4.png" %}
 
-<br>
-<div class="row">
-  <div class="col-sm-12 col-md">
-    <img src="../../assets/images/gui/apiarygui4.png" class="img-fluid mx-auto" alt="Apiary GUI 4">
-  </div>
-  <div class="col-sm-12 col-md">
-    <br>
-    <p>The fourth tab of the GUI is <strong>Flowers</strong>.  Here you designate what flowers you want the Beekeeper to request and use during breeding.  By default, all flowers are turned off.</p>
-  </div>
-</div>
-
-<br>
-<div class="row">
-  <div class="col-sm-12 col-md">
-    <img src="../../assets/images/gui/apiarygui5.png" class="img-fluid mx-auto" alt="Apiary GUI 5">
-  </div>
-  <div class="col-sm-12 col-md">
-    <br>
-    <p>The fifth tab of the GUI is the <strong>Hive Tool</strong>.</p>
-    <ul>
-      <li><b>Obtain Tool:</b> Click this button to get the hive tool, which is how you select which hives the Beekeeper will take care of. To select a hive, right-click on it with the hive tool. Right-click on a hive again to remove it.</li>
-    </ul>
-  </div>
-</div>
+    {% include contentblock/basic.html header="The fifth tab of the GUI is <strong>Hive Tool</strong>." content="Click this button to get the hive tool, which is how you select which hives the Beekeeper will take care of. To select a hive, right-click on it with the hive tool. Right-click on a hive again to remove it." image="../../assets/images/gui/apiarygui5.png" %}
   </div>
 </div>


### PR DESCRIPTION
## Changes proposed:
- Currently the individual pages have quite a lot of recurring code and a lot of HTML in Markdown pages.
I propose a setup where we use more include files to contain some of the generic HTML code and then use parameters into those includes to configure them to show specific content. I've provided a setup for the Apiary here, I'd like some feedback on this and I'll expand this to the other pages aswell in the meantime.

Merge please :D
