### PR TITLE
Update troubleshooting.md

### DIFF
--- a/pages/src/source/misc/troubleshooting.md
+++ b/pages/src/source/misc/troubleshooting.md
@@ -31,7 +31,7 @@ layout: default
 If none of these apply, go on to the next troubleshooting checklists.  
 
 ### CHECKLIST: Troubleshooting a citizen not working by career
-  1. [Builder](../../source/workers/builder): Remember to click the Build Building button inside the hut block you want to be built, then wait for the Builder to announce they have begun building. If you are upgrading a building, check that the builder's hut is the same level or higher than the building you are upgrading.
+  1. [Builder](../../source/workers/builder): Remember to click the Build Building button inside the hut block you want to be built, then wait for the Builder to announce they have begun building. If you are upgrading a building, check that the Builder's Hut level is higher than the building you are upgrading.
   2. [Forester](../../source/workers/forester): Set which type of tree they are allowed to cut and if they should replant them. Make sure that your trees are at ground level, or if you place them one block higher, place slabs next to them.
   3. [Miner](../../source/workers/miner): Is there an ore they cannot mine in their way? Break it for them or assign them to a new mining level. Do they have cobblestone, torches, a pickaxe, a shovel, slabs, planks, and fencing (for the mineshaft)?
   4. [Cook](../../source/workers/cook): Set which fuel you want them to use.

--- a/pages/src/source/misc/troubleshooting.md
+++ b/pages/src/source/misc/troubleshooting.md
@@ -31,7 +31,7 @@ layout: default
 If none of these apply, go on to the next troubleshooting checklists.  
 
 ### CHECKLIST: Troubleshooting a citizen not working by career
-  1. [Builder](../../source/workers/builder): Remember to click the Build Building button inside the hut block you want to be built, then wait for the {% include building/builder.html key="builder" %} to announce they have begun building. If you are upgrading a building, check that the {% include building/builder.html key="builder" %} level is higher than the building you are upgrading.
+  1. [Builder](../../source/workers/builder): Remember to click the Build Building button inside the hut block you want to be built, then wait for the {% include links/building.html key="builder" %} to announce they have begun building. If you are upgrading a building, check that the {% include links/building.html key="builder" %} level is higher than the building you are upgrading.
   2. [Forester](../../source/workers/forester): Set which type of tree they are allowed to cut and if they should replant them. Make sure that your trees are at ground level, or if you place them one block higher, place slabs next to them.
   3. [Miner](../../source/workers/miner): Is there an ore they cannot mine in their way? Break it for them or assign them to a new mining level. Do they have cobblestone, torches, a pickaxe, a shovel, slabs, planks, and fencing (for the mineshaft)?
   4. [Cook](../../source/workers/cook): Set which fuel you want them to use.

--- a/pages/src/source/misc/troubleshooting.md
+++ b/pages/src/source/misc/troubleshooting.md
@@ -31,7 +31,7 @@ layout: default
 If none of these apply, go on to the next troubleshooting checklists.  
 
 ### CHECKLIST: Troubleshooting a citizen not working by career
-  1. [Builder](../../source/workers/builder): Remember to click the Build Building button inside the hut block you want to be built, then wait for the Builder to announce they have begun building. If you are upgrading a building, check that the Builder's Hut level is higher than the building you are upgrading.
+  1. [Builder](../../source/workers/builder): Remember to click the Build Building button inside the hut block you want to be built, then wait for the {% include building/builder.html key="builder" %} to announce they have begun building. If you are upgrading a building, check that the {% include building/builder.html key="builder" %} level is higher than the building you are upgrading.
   2. [Forester](../../source/workers/forester): Set which type of tree they are allowed to cut and if they should replant them. Make sure that your trees are at ground level, or if you place them one block higher, place slabs next to them.
   3. [Miner](../../source/workers/miner): Is there an ore they cannot mine in their way? Break it for them or assign them to a new mining level. Do they have cobblestone, torches, a pickaxe, a shovel, slabs, planks, and fencing (for the mineshaft)?
   4. [Cook](../../source/workers/cook): Set which fuel you want them to use.

--- a/pages/src/source/misc/troubleshooting.md
+++ b/pages/src/source/misc/troubleshooting.md
@@ -31,7 +31,7 @@ layout: default
 If none of these apply, go on to the next troubleshooting checklists.  
 
 ### CHECKLIST: Troubleshooting a citizen not working by career
-  1. [Builder](../../source/workers/builder): Remember to click the Build Building button inside the hut block you want to be built, then wait for the Builder to announce they have begun building.
+  1. [Builder](../../source/workers/builder): Remember to click the Build Building button inside the hut block you want to be built, then wait for the Builder to announce they have begun building. If you are upgrading a building, check that the builder's hut is the same level or higher than the building you are upgrading.
   2. [Forester](../../source/workers/forester): Set which type of tree they are allowed to cut and if they should replant them. Make sure that your trees are at ground level, or if you place them one block higher, place slabs next to them.
   3. [Miner](../../source/workers/miner): Is there an ore they cannot mine in their way? Break it for them or assign them to a new mining level. Do they have cobblestone, torches, a pickaxe, a shovel, slabs, planks, and fencing (for the mineshaft)?
   4. [Cook](../../source/workers/cook): Set which fuel you want them to use.


### PR DESCRIPTION
Sometimes, if you upgrade a building without specifying which builder will do it, and the one the system selects has no enough hut level, you don't see the message warning about the lack of level, instead, it puts the tape but the builder never starts.

Closes #

## Changes proposed:
- 
- 

Merge please :D
