### PR TITLE
Update the schematics tutorial to reflect the new build tool in 1.19

### DIFF
--- a/pages/src/source/tutorials/schematics.md
+++ b/pages/src/source/tutorials/schematics.md
@@ -6,10 +6,15 @@ layout: default
 
 Schematics are files containing block and entity information of a certain area a player scanned with the [Scan Tool](../items/scantool) in-game. You can use the scan tool and scan ANY building or structure you like in singleplayer or multiplayer and then have your [Builder](../../source/workers/builder) build it for you (provided that you give them all the materials needed, of course).
 
+### Note: In 1.19, the build tool and the schematic infrastructure changed. This means that parts of the information below may only apply to one of both versions. Those parts are annotated with [1.18] and [1.19]. Anything not annotated holds for both versions
+
+
 - [Schematics](#schematics)
   - [Scanning a New Structure](#scanning-a-new-structure)
   - [Placing a Schematic.](#placing-a-schematic)
+  - [Style packs](#style-packs) [1.19]
   - [FAQ](#faq)
+      - [How do I install custom schematics I just downloaded?](#how-do-i-install-custom-schematics-i-just-downloaded)
       - [What and Where is the scans folder?](#what-and-where-is-the-scans-folder)
       - [Where is the schematic folder?](#where-is-the-schematic-folder)
       - [I have a "*/minecolonies/01e6a291-8a01-4763-bcae-f3a8797b1d52/cache/" folder, what is that for?](#i-have-a-%22minecolonies01e6a291-8a01-4763-bcae-f3a8797b1d52cache%22-folder-what-is-that-for)
@@ -36,37 +41,83 @@ Then click in the air to see the entire structure.
 
 ![ScanFull](../../assets/images/tutorial/scan3.png)
 
-Once you have the full area set, you can press Escape and the white outline of the scan area will stay in place. Go around it to double-check that everything you want is in the scan area. When you are ready, you can right-click in the air again to get the GUI to display where you can enter your scan name. Then press the green checkmark to save the scan.
+Once you have the full area set, you can press Escape and the white outline of the scan area will stay in place. Go around it to double-check that everything you want is in the scan area. If the area contains multiple eligible anchor blocks (hut blocks, tag anchors or decoration controllers), you need to shift+left click the correct anchor block (e.g. the barracks hut block in a barracks schematic). When you are ready, you can right-click in the air again to get the GUI to display where you can enter your scan name. Then press the green checkmark to save the scan.
 
-Scans are saved in `../minecolonies/scan/new/...`
+Scans are saved in `../minecolonies/scan/new/...` [1.18] or `*/blueprints/<yourplayername>/scans` [1.19]
 
-Once the scans are saved, they need to be moved to the `../structurize/schematics/(folder)/file` if they are a <a href="#customhuts">custom hut</a>.
+[1.18] Once the scans are saved, they need to be moved to the `../structurize/schematics/(folder)/file` if they are a <a href="#customhuts">custom hut</a>.
+[1.19] Once the scans are saved, they need to be placed in a style pack, preferably in the correct folder. See the [style packs](#style-packs) chapter for more details.
 
 ## Placing a Schematic.
 
-Once you have scanned a structure, you can use the [build tool](../../source/items/buildtool) to have your [Builder](../../source/workers/builder) build it for you. Once you right-click with the build tool, you will have to select "My Schematics" (in the left dropdown menu) and on the right dropdown menu you will see the scans that you have made. There is also a Rename button where you can change the name of the scan. You can also delete any of your saved scans.
+[1.18] Once you have scanned a structure, you can use the [build tool](../../source/items/buildtool) to have your [Builder](../../source/workers/builder) build it for you. Once you right-click with the build tool, you will have to select "My Schematics" (in the left dropdown menu) and on the right dropdown menu you will see the scans that you have made. There is also a Rename button where you can change the name of the scan. You can also delete any of your saved scans.
 
 ![Schematic](../../assets/images/tutorial/schematic.png)
+
+[1.19] The scanned structure can be found in the [build tool](../../source/items/buildtool) under the style pack with your own name. Click "Switch Pack" -> "&lt;yourplayername&gt;" (icon looks like the scan tool) -> "scans". 
+
+## Style packs
+([1.19] only)
+
+Styles are now structured in so-called style packs. This is similar to a resource pack or data pack, in that it has a file with some metadata about the style (the name, a description, optionally a link to an image, etc.), and a folder structure with the actual files.
+
+Stylepacks live in the blueprints folder, within your Minecraft folder. This folder already contains one style pack: One with your player's name. This style pack will contain your scanned files, and can be used to test schematics. In order to make a new style, you need to make a new schematic pack.
+
+### The pack.json
+This json file contains metadata describing the style:
+| Key Name                               | Type             | Description |
+| -------------------------------------- | ---------------- | ----------- |
+| <code>"version"</code>                 | number           | Pack version, 1 at the moment |
+| <code>"pack-format"</code>             | number           | Descriptor for the pack format, needs to be 1 at the moment |
+| <code>"desc"</code>                    | string           | Description of the style. This will be visible in the build tool to explain what your style is about |
+| <code>"authors"</code>                 | array of strings | Names of the authors, in order to credit them. This is visible in the build tool |
+| <code>"mods"</code>                    | array of strings | Names of used mods (ids). The style is not visible if one of those mods is not installed, to prevent broken schematics |
+| <code>"name"</code>                    | string           | The name of the style pack |
+| <code>"icon"</code>                    | string           | The name of the file with an icon which is showed in the style packs selection screen |
+
+### The folder structure
+
+There are several folders, separating the buildings and decorations in categories.
+Each of the folders at the highest level can have a couple of icons, named `icon.png` and `icon_disabled.png`. Those are shown in the button bar right above the hot bar.
+
+You can download a template folder structure from [github](https://github.com/ldtteam/minecolonies/tree/version/1.19/src/main/resources/blueprints/minecolonies) (template.zip), which contains the icons used for the official styles already.
+That github page also contains examples how different styles are structured.
+An overview with which buildings go into which folders can also be found [here](https://airtable.com/shruNNUKhTNk0saz5).
+
+Decorations are less strict. You can make categories for them as you see fit. E.g. if you have two styles of roads, one for early game and one for later game, you could put them in infrastructure/roads/simple/ and infrastructure/roads/nice/.
+
+**Note:** Each folder can only contain folders or files. If there are folders there, files won't be visible in the build tool!
 
 ## FAQ
 
 This is a FAQ section to answer common questions regarding schematics in MineColonies.
 
+#### How do I install custom schematics I just downloaded?
+
+[1.18] Those custom schematics go in `*/structurize/schematics`. Unzip the zip you downloaded, and put all subfolders in the schematics folder. That folder should contain folders like &lt;stylename&gt;, decorations, walls, supplycamps etc. (depending on which style you installed)
+[1.19] The style pack goes in the "blueprints" folder. Unzip the zip, and find the folder containing the pack.json (either the unzipped folder, or a folder directly in it, depending on how the zip was made). This folder needs to be placed in `*/blueprints`
+
 #### What and where is the scans folder?
 
-The scans folder is where the schematics are saved after performing a scan using the scan tool in MineColonies. This is a client-side-only directory which is located in Minecraft's folder under: `*/structurize/scans/`. Freshly scanned schematics can be found in `*/structurize/scans/new/` unless they have been renamed in-game. (If they aren't there, look in `*/minecolonies/scans/new`.) This directory is shared between all your singleplayer games and multiplayer games.
+The scans folder is where the schematics are saved after performing a scan using the scan tool in MineColonies.
+[1.18] This is a client-side-only directory which is located in Minecraft's folder under: `*/structurize/scans/`. Freshly scanned schematics can be found in `*/structurize/scans/new/` unless they have been renamed in-game. (If they aren't there, look in `*/minecolonies/scans/new`.) This directory is shared between all your singleplayer games and multiplayer games.
+[1.19] This is located in your own style pack in Minecraft's folder under: `*/blueprints/<yourplayername>/scans/`. This folder is shared between all your singleylayer and multiplayer games.
 
 #### Where is the schematic folder?
 
-Custom schematics need to be copied inside the schematic folder. For both singleplayer and multiplayer games, the folder is under `*/structurize/schematics/`.
+[1.18] Custom schematics need to be copied inside the schematic folder. For both singleplayer and multiplayer games, the folder is under `*/structurize/schematics/`.
+[1.19] Custom schematics need to be placed in a (custom) [style pack](#style-packs). For more information about that, look there.
 
 #### I have a "*/minecolonies/01e6a291-8a01-4763-bcae-f3a8797b1d52/cache/" folder, what is that for?
 
-When playing on a server, the server needs to send the schematics to the players so that the build tool's preview works. Those schematics are saved in Minecraft's directory under `*/structurize/{ServerUUID}/cache/`, where ServerUUID is the unique identifier of the server. Those directories can be safely removed as they are automatically created by the server when needed.
+[1.18] When playing on a server, the server needs to send the schematics to the players so that the build tool's preview works. Those schematics are saved in Minecraft's directory under `*/structurize/{ServerUUID}/cache/`, where ServerUUID is the unique identifier of the server. Those directories can be safely removed as they are automatically created by the server when needed.
 
 #### How to create <a id="customhuts">custom huts</a>?
 
-To create new schematics, there are some guidelines that you must follow: the scans MUST have the same footprint for each level of the hut; the scans must contain the hut's block, for example the Builder's Hut block for the [Builder's Hut](../../source/buildings/builder); the hut block need to be exactly at the same place and have the same rotation for each level; the scans' filenames need to follow the naming convention: {StyleName}/{HutName}{HutLevel}.blueprint. For example, for the Builder's Huts with the MyOwn style, we would have:
+To create new schematics, there are some guidelines that you must follow: the scans MUST have the same footprint for each level of the hut; the scans must contain the hut's block, for example the Builder's Hut block for the [Builder's Hut](../../source/buildings/builder); the hut block need to be exactly at the same place and have the same rotation for each level
+
+[1.18]
+The scans' filenames need to follow the naming convention: {StyleName}/{HutName}{HutLevel}.blueprint. For example, for the Builder's Huts with the MyOwn style, we would have:
 
 *myown/builder1.blueprint*
 *myown/builder2.blueprint*
@@ -75,6 +126,8 @@ To create new schematics, there are some guidelines that you must follow: the sc
 *myown/builder5.blueprint*
 
 - **Note:** In the [build tool](../../source/items/buildtool), the extension is hidden. HutName can be any of the listed huts below. The maximum level is 5 (except for the Tavern; its max level is 3).
+
+Alternative designs can be placed under as style name like "myownalternative".
 
 <!-- For the new build tool; uncomment this when it's ready
 If you have alternative designs for the same hut, the alternative huts can go in the same folder as the regular hut. 
@@ -91,7 +144,14 @@ Once ready, move the `myown` folder into the schematics folder and start your ga
 
 **Note:** Remember that you need the appropriate hut in your inventory to be able to see the schematics in the build tool.
 
-## Custom Hut Filenames
+[1.19]
+The naming for the buildings is not strict anymore. The only thing that is important is that they are named consistently, and that their names end with the hut level.
+Alternate designs can just have a different name than the primary one. E.g. if you named the level 1 builder's hut "builder1", an alternative version could be called "altbuilder1" or "builderalt1" or even something completely different ("constructionworker1").
+
+Once ready, you need to make a [style pack](#style-packs) out of them.
+The schematics are visible in the build tool without the hut block, but you can't view them in survival mode (their button is greyed out, with an error message that you need to have the hut block)
+
+## [1.18] Custom Hut Filenames
 
 Here is a full list, up-to-date as of 20 January 2021, of the building names. Please note that *capitalization matters*.
 
@@ -149,12 +209,15 @@ Here is a full list, up-to-date as of 20 January 2021, of the building names. Pl
 
 The process for custom [supply ships and camps](../../source/items/supplycampandship) is slightly different: 
 
-| Camp or Ship | File Name and Path |
-| :----------: | :----------------: |
-| Camp | structurize/schematics/supplycamp/myownsupplycamp |
-| Ship | structurize/schematics/supplyship/myownsupplyship |
+| Version | Camp or Ship | File Name and Path |
+| :-----: | :----------: | :----------------: |
+| [1.18]  | Camp | structurize/schematics/supplycamp/myownsupplycamp |
+| [1.18]  | Ship | structurize/schematics/supplyship/myownsupplyship |
+| [1.19]  | Camp | blueprints/&lt;myownstyle&gt;/decorations/supplies/supplycamp |
+| [1.19]  | Ship | blueprints/&lt;myownstyle&gt;/decorations/supplies/supplyship |
 
-So, for example, the path would be `structurize/schematics/wildwest/builder1` for the Builder's Hut level 1 and `structurize/schematics/supplycamp/wildwestsupplycamp` for the supply camp.
+[1.18] So, for example, the path would be `structurize/schematics/wildwest/builder1` for the Builder's Hut level 1 and `structurize/schematics/supplycamp/wildwestsupplycamp` for the supply camp.
+[1.19] So, for example, the path would be `blueprints/wildwest/fundamentals/builder1` for the Builder's Hut level 1 and `blueprints/wildwest/decoration/supplies/supplycamp` for the supply camp.
 
 ## Hut Requirements
 
@@ -225,7 +288,7 @@ Some buildings may also require tags to be set on certain blocks using the [tag 
   <li>Use <a href="../../source/items/placeholderblocks">solid placeholders</a> at or below ground level</li>
   <li>Place a <a href="../../source/items/tagtool"><code>groundlevel</code> tag</a> at ground level if your hut isn't sitting directly on the ground.</li>
   <li>Use only vanilla blocks or Structurize blocks (for official styles)</li>
-  <li>Use Books and Quills instead of blank books</li>
+  <li>Use Books and Quills instead of blank books, or written books on a lectern. (Keep a copy of the original book and quill somewhere, if it turns out you made a mistake!)</li>
 </ul>
 
 ### Don't 
@@ -238,11 +301,12 @@ Some buildings may also require tags to be set on certain blocks using the [tag 
 
 ### How to override some built-in schematics?
 
-Simply create a schematic file with the same style/name. For instance, to override the [Builder's Hut](../../source/buildings/builder) wooden level 1, create a schematic file name called wooden/builder1.blueprint.
+[1.18] Simply create a schematic file with the same style/name. For instance, to override the [Builder's Hut](../../source/buildings/builder) wooden level 1, create a schematic file name called wooden/builder1.blueprint.
+[1.19] Unfortunately, this is not possible, unless you override the entire style (make a style pack with the same name as an existing style pack, in that case).
 
 ### How to use custom huts?
 
-The custom huts need to be copied in the schematics folder. Once copied, you can start your singleplayer or multiplayer game as usual. You should see them in the [build tool](../../source/items/buildtool) (if you have the hut block in your inventory).
+The custom huts need to be copied in the schematics folder [1.18] or in a style pack [1.19]. Once copied, you can start your singleplayer or multiplayer game as usual. You should see them in the [build tool](../../source/items/buildtool) (if you have the hut block in your inventory).
 
 ### How to allow my players to use their own huts' schematics on my server?
 
@@ -258,6 +322,7 @@ Edit the Structurize configuration file at `minecraft/config/structurize-common.
 
 ### How to create upgradable decoration schematics?
 
-Add the [deco controller](../../source/items/decocontroller) somewhere in the schematic with the name of the schematic, where you'll put it in the file directory, and its level. Make sure to actually put the decoration in that file path, but only after scanning - don't include the path in the scan name.
+[1.18] Add the [deco controller](../../source/items/decocontroller) somewhere in the schematic with the name of the schematic, where you'll put it in the file directory, and its level. Make sure to actually put the decoration in that file path, but only after scanning - don't include the path in the scan name.
+[1.19] Put the [deco controller](../../source/items/decocontroller) somewhere in the schematic, and make sure the name of the schematic ends with a number while scanning. The decoration controller will automatically find the decoration in the same folder with the next number.
 
 ![Upgradable Decos](../../assets/images/tutorial/upgradabledecos.png)


### PR DESCRIPTION
Closes #

## Changes proposed:
- Update the wiki with the new schematic infrastructure. As parts of the information applies for both, I chose to label the version-specific lines with \[1.18] (for the old build tool) and \[1.19] (for the new one).
- Add information about setting an anchor block manually while scanning
- Add information about alternate buidings (how to handle those in both versions)
- Note that written books work on a lectern
- Add an instruction on how to install custom styles (in both versions)

Merge please :D
