### PR TITLE
Citizen names in datapack

### DIFF
--- a/pages/src/source/misc/customcitizennames.md
+++ b/pages/src/source/misc/customcitizennames.md
@@ -15,13 +15,14 @@ Everything you have to change is in one file.
 
 2. Edit
 
-   You need to make a file named "default.json" in the citizennames data location (put it in `data/<somenamespace>/citizennames`)
+   If you decided you create one yourself, you need to make a file named "default.json" in the citizennames data location (put it in `data/<somenamespace>/citizennames`)
    You can use the official language templates we provide here for inspiration,
    or you can make one yourself at your own risk. In the latter case, make sure that there are enough names in the datapack! Otherwise minecolonies may crash due to it running out of name combinations.
    <br>
     <ul>
    <li>Edit with a text editor, like Notepad.</li>
    <li>Name it default.json, to make sure everyone can use the new names.</li>
+   <li>The <a href="../../source/tutorials/datapacks#citizen-names">datapacks</a> page has an explanation of the format of the file</li>
     </ul>
 
 3. Install the datapack on the client or server, in the data folder within the world folder.

--- a/pages/src/source/misc/customcitizennames.md
+++ b/pages/src/source/misc/customcitizennames.md
@@ -10,25 +10,37 @@ Everything you have to change is in one file.
 
 ## Procedure
 
-1. Locate the file _minecolonies-server.toml_. For information on how to find it, see the [config file](../../source/misc/configfile) page.<br>
+1. You need to have a datapack. You can either download one from the official datapacks below, or create your own. The [datapacks](../../source/tutorials/datapacks) page has more information about how to make one, as well as the Minecraft wiki
 
 
 2. Edit
 
-   You can use the official language templates we provide here, or you can edit at your own risk. If you decide to edit,
-   don't forget to make a copy of the file first and follow the current structure.
+   You need to make a file named "default.json" in the citizennames data location (put it in `data/<somenamespace>/citizennames`)
+   You can use the official language templates we provide here for inspiration,
+   or you can make one yourself at your own risk. In the latter case, make sure that there are enough names in the datapack! Otherwise minecolonies may crash due to it running out of name combinations.
    <br>
     <ul>
    <li>Edit with a text editor, like Notepad.</li>
-   <li>The file must have the same name.</li>
+   <li>Name it default.json, to make sure everyone can use the new names.</li>
     </ul>
 
+3. Install the datapack on the client or server, in the data folder within the world folder.
 
-3. Run Minecraft client/server and enjoy!
+4. Run Minecraft client/server and enjoy!
 
 <br>
 
+## Official Datapacks
+
+### Russian
+
+[Download Russian Data Pack](../../source/misc/languageDatapacks/russianDatapack.zip)
+
+*Credit to TanLorikk*
+
 ## Official Language Templates
+
+Note that the template files are outdated now, but they can be a great source of inspiration, in order to make your own citizen name file!
 
 ### Chinese
 
@@ -69,8 +81,6 @@ Everything you have to change is in one file.
 *Credit to Holmis*
 
 ### Russian
-
-[Download Russian Data Pack](../../source/misc/languageDatapacks/russianDatapack.zip)
 
 [Download Russian Template File](../../source/misc/languageNameTemplates/russianTemplate.toml)
 

--- a/pages/src/source/tutorials/datapacks.md
+++ b/pages/src/source/tutorials/datapacks.md
@@ -348,10 +348,10 @@ There are also sample data packs on the [citizen names](../../source/misc/custom
 
 The citizen name files have the following components:
 
-| Citizen Name Key Name         | Type       | Description |
+| Key Name                      | Type       | Description |
 | ----------------------------- | ---------- | ----------- |
 | <code>"parts"</code>          | integer    | `2` or `3`. This determines whether a middle letter is used in the name (if it is 3) |
 | <code>"order"</code>          | string     | `"WESTERN"` or `"EASTERN"`. In case of EASTERN, the surname is shown first |
 | <code>"male_firstname"</code> | Array of Strings | A list of the male first names |
-| <code>"female_firstname"</code> | array of strings | A list of the female first names |
+| <code>"female_firstname"</code> | Array of Strings | A list of the female first names |
 | <code>"surnames"</code>       | Array of Strings | A list of the surnames for the citizens |

--- a/pages/src/source/tutorials/datapacks.md
+++ b/pages/src/source/tutorials/datapacks.md
@@ -20,6 +20,7 @@ layout: default
   - [Research Effects](#research-effects)
   - [MineColonies Research Effects](#minecolonies-research-effects)
   - [MineColonies Building Unlocks](#minecolonies-building-unlocks)
+- [Citizen names](#citizen-names)
 
 MineColonies allows modifications of many features using data packs, including player and worker recipes, loot tables, and mob drops. This allows broad expansion by players or modpack makers to support other mods, design choices, forms of progression, or styles of play. For general information on Minecraft data packs, [see the official wiki](<https://Minecraft.fandom.com/wiki/Data_Pack>).
 
@@ -35,7 +36,7 @@ For most users, looking at other similar JSONs will be the fastest way to get st
 
 The data pack folder or zip file can be any valid file name, and will be used to determine the name of the data pack. This folder or zip file must contain in its root level a file named **pack.mcmeta**, [with a specific format](<https://Minecraft.gamepedia.com/Data_Pack#pack.mcmeta>). It is strongly encouraged to provide a distinct name and description for your data pack: this will show up as a tooltip from the in-game interfaces and /datapack list command. To act as a data pack, this should also contain a "data" directory.
 
-Each folder within that "data" directory acts as a different **namespace**. Most mods have their own namespaces; for MineColonies, this is "minecolonies". As a rule, all folders and files within a datapack, including the namespace folders, **must** have names consisting solely of lowercase alphanumeric characters, underscores (_), dashes (-), and/or dots (.). Any other characters, including uppercase letters, will cause Minecraft to fail to load the data pack, and give a largely unhelpful error. Completely empty names are considered legal and read, but not all mods will support them.
+Each folder within that "data" directory acts as a different **namespace**. Most mods have their own namespaces; for MineColonies, this is "minecolonies". As a rule, all folders and files within a datapack, including the namespace folders, **must** have names consisting solely of lowercase alphanumeric characters, underscores (`_`), dashes (-), and/or dots (.). Any other characters, including uppercase letters, will cause Minecraft to fail to load the data pack, and give a largely unhelpful error. Completely empty names are considered legal and read, but not all mods will support them.
 
 <p style="font-size:12pt;text-align:center"><b>Data packs are very picky. A single misplaced comma, missing quotation mark, or invalid file name will give an error. If a file doesn't seem to be applying, or a datapack is giving errors on world load, check your file's formatting first.</b></p>
 Files that exactly match the namespace, directory, and name of a file from vanilla Minecraft, a mod, or another data pack will either completely override or merge with that other JSON, depending on the file's type. A data pack can have multiple namespace directories, and the most common approach is to use a mod's namespace when directly overriding an existing JSON from vanilla or a mod, and a unique namespace when adding or modifying content or modifying another data pack. It's encouraged to add to the <code>forge</code> and <code>minecraft</code> namespaces only when adding to or modifying vanilla or forge defaults, to use the <code>minecolonies</code> namespace when modifying existing MineColonies files, and to use your own namespace when adding new types, or completely removing a crafter recipe or research.
@@ -338,3 +339,19 @@ Research Effects may also optionally unlock a building. These reserved Resource 
 |blockhutrabbithutch  |blockhutsawmill      |blockhutschool       |blockhutshepherd     |blockhutsifter     |
 |blockhutsmeltery     |blockhutstonemason   |blockhutstonesmeltery|blockhutswineherder  |blockhuttavern     |
 |blockhuttownhall     |blockhutuniversity   |blockhutwarehouse    |                     |                   |
+
+## Citizen names
+
+Citizen names can be changed via a datapack. For the ones already in the mod, you can look it [Github](https://github.com/ldtteam/minecolonies/blob/version/1.19/src/main/resources/data/minecolonies/citizennames) The default.json file is loaded by default, patreons have a button in the town hall to change to any of the other ones in data packs in the `citizennames` data location.
+
+There are also sample data packs on the [citizen names](../../source/misc/customcitizennames) page
+
+The citizen name files have the following components:
+
+| Citizen Name Key Name         | Type       | Description |
+| ----------------------------- | ---------- | ----------- |
+| <code>"parts"</code>          | integer    | `2` or `3`. This determines whether a middle letter is used in the name (if it is 3) |
+| <code>"order"</code>          | string     | `"WESTERN"` or `"EASTERN"`. In case of EASTERN, the surname is shown first |
+| <code>"male_firstname"</code> | Array of Strings | A list of the male first names |
+| <code>"female_firstname"</code> | array of strings | A list of the female first names |
+| <code>"surnames"</code>       | Array of Strings | A list of the surnames for the citizens |


### PR DESCRIPTION
Closes #912

## Changes proposed:
- Add a section to the datapacks page to explain the format of the citizen names datapack files 
- Rework the custom citizen names page to make clear they go via datapacks now, instead of via a config file.
  In order to make more clear which ones can be downloaded and actually used in game,
  and which one are outdated and could be used for inspiration, I separated those in different sections
