### PR TITLE
Remove old versions from version selector

### DIFF
--- a/pages/src/_data/versions.yml
+++ b/pages/src/_data/versions.yml
@@ -3,19 +3,19 @@
   supported: false
 - name: "1.18"
   order: 11800
-  supported: true
+  supported: false
 - name: "1.18.1"
   order: 11801
-  supported: true
+  supported: false
 - name: "1.18.2"
   order: 11802
   supported: true
 - name: "1.19"
   order: 11900
-  supported: true
+  supported: false
 - name: "1.19.1"
   order: 11901
-  supported: true
+  supported: false
 - name: "1.19.2"
   order: 11902
   supported: true

--- a/pages/src/_includes/util/version-select.html
+++ b/pages/src/_includes/util/version-select.html
@@ -1,8 +1,11 @@
 <select class="custom-select version-switch">
+  <optgroup label="Supported versions" class="version-supported">
   {% assign versions = site.data.versions | sort: "order" | reverse %}
   {% for version in versions %}
     {% if version.supported %}
       <option class="version-supported" value="{{ version.order }}">{{- version.name -}}</option>
     {% endif %}
   {% endfor %}
+  </optgroup>
+  <optgroup label="Unsupported versions" class="version-not-supported"></optgroup>
 </select>

--- a/pages/src/_includes/util/version-select.html
+++ b/pages/src/_includes/util/version-select.html
@@ -3,8 +3,6 @@
   {% for version in versions %}
     {% if version.supported %}
       <option class="version-supported" value="{{ version.order }}">{{- version.name -}}</option>
-    {% else %}
-      <option class="version-not-supported" value="{{ version.order }}">{{- version.name -}}</option>
     {% endif %}
   {% endfor %}
 </select>

--- a/pages/src/_sass/main.scss
+++ b/pages/src/_sass/main.scss
@@ -150,6 +150,10 @@ $mcurl: "https://minecolonies.com";
 
 .version-not-supported {
   color: red;
+
+  &:empty {
+    display: none;
+  }
 }
 
 .version-supported {

--- a/pages/src/assets/js/version-select.js
+++ b/pages/src/assets/js/version-select.js
@@ -18,24 +18,17 @@ function updateVersion(version, persist = true, addIfNotExist = false) {
   document.body.setAttribute("data-version", version.order);
   Array.from(document.getElementsByClassName("version-switch")).forEach((element) => {
     element.value = version.order;
-    if (version.supported) {
-      element.classList.remove("version-not-supported");
-    } else {
-      element.classList.add("version-not-supported");
-    }
 
-    const item = element.children.namedItem(`version-${version.order}`);
-    if (addIfNotExist && item === null) {
-      const newOpt = document.createElement("option");
-      if (version.supported) {
-        newOpt.classList.add("version-supported");
-      } else {
-        newOpt.classList.add("version-not-supported");
+    const notSupportedList = element.querySelector(`.version-not-supported`);
+    if (notSupportedList != null) {
+      const item = notSupportedList.querySelector(`option[value="${version.order}"]`);
+      if (addIfNotExist && item === null) {
+        const newOpt = document.createElement("option");
+        newOpt.value = version.order;
+        newOpt.innerText = version.name;
+        notSupportedList.appendChild(newOpt);
+        element.value = version.order;
       }
-      newOpt.value = version.order;
-      newOpt.innerText = version.name;
-      element.appendChild(newOpt);
-      element.value = version.order;
     }
   });
 }

--- a/pages/src/assets/js/version-select.js
+++ b/pages/src/assets/js/version-select.js
@@ -6,9 +6,7 @@ function docReady(fn) {
   }
 }
 
-function updateVersion(version, persist) {
-  persist = persist ?? true;
-
+function updateVersion(version, persist = true, addIfNotExist = false) {
   const currentVersion = document.body.getAttribute("data-version");
   if (currentVersion === version.order) {
     return;
@@ -24,6 +22,20 @@ function updateVersion(version, persist) {
       element.classList.remove("version-not-supported");
     } else {
       element.classList.add("version-not-supported");
+    }
+
+    const item = element.children.namedItem(`version-${version.order}`);
+    if (addIfNotExist && item === null) {
+      const newOpt = document.createElement("option");
+      if (version.supported) {
+        newOpt.classList.add("version-supported");
+      } else {
+        newOpt.classList.add("version-not-supported");
+      }
+      newOpt.value = version.order;
+      newOpt.innerText = version.name;
+      element.appendChild(newOpt);
+      element.value = version.order;
     }
   });
 }
@@ -57,10 +69,10 @@ docReady(function() {
   }
 
   if (fixedVersionFound) {
-    updateVersion(fixedVersion, false);
+    updateVersion(fixedVersionFound, false, true);
   } else if (preferredVersionFound) {
-    updateVersion(preferredVersionFound, false);
+    updateVersion(preferredVersionFound, false, !preferredVersionFound.supported);
   } else {
-    updateVersion(latest_version, false);
+    updateVersion(latest_version, false, false);
   }
 });


### PR DESCRIPTION
## Changes proposed:
- Remove the unsupported versions from the dropdown in the wiki
- Users can still type `?version=1.16.5` or similar to pull up a specific version in the wiki (for example links that were sent in the archived support channels) to view old content
- When people have previously selected a version, it will remain that version like it used to do, however when that version has gone unsupported between updates, it will still show in the dropdown, but red
- When viewing an unsupported version (through either of the above methods) it will show red in the version select dropdown with a temporary created version in the dropdown
