### PR TITLE
Add Structurize Frame crafting info to Carpenter wiki page

### DIFF
--- a/pages/src/source/workers/carpenter.md
+++ b/pages/src/source/workers/carpenter.md
@@ -20,4 +20,6 @@ The Carpenter is a part of your colony's production line. The Carpenter can lear
 All crafters have a chance to decrease the amount of materials needed for a taught recipe. (If this happens, the new recipe is kept until deleted or improved again.) The higher a Carpenter's Knowledge level is, the greater their chance to decrease the amount of materials needed.
 
 The higher a Carpenter's Dexterity level is, the faster they'll craft.
+
+The Carpenter can craft all variants of Structurize's Frames if tought their base recipe and doesn't need the build tool to do it. (E.g. if you teach the recipe for Vertical Oak Cobblestone Timber Frame, they will also know Crossed Oak Cobblestone Timber Frame, etc., but they won't e.g. know Vertical *Spruce* Cobblestone Timber Frame until tought.)
 {% endinfobox_worker %}


### PR DESCRIPTION
## Changes proposed:
- Add info about Carpenter crafting Structurize blocks to it's wiki page:\
As JEI shows the recipe for Structurize blocks not needing the Build Tool I was a bit stumped on what if even I had to teach the Carpenter for them to craft those (and didn't just try but searched a while until I found some post on Reddit about it). I'd say it would be good to have this info on the wiki page directly, since this was the first place I looked, but couldn't find anything.