### PR TITLE
Update netherminer wiki page to include loot table

### DIFF
--- a/src/content/wiki/workers/netherminer.mdoc
+++ b/src/content/wiki/workers/netherminer.mdoc
@@ -21,7 +21,13 @@ The Nether Miner requires significant supplies. They require the following items
 | 32 torches (gets used up)     |
 | 16 ladders (gets used up)     |
 
-Once they have their tools & items, they will activate the nether portal and travel to the nether.  The nether is dangerous! They will fight mobs they encounter there, and it is possible for them to die on the trip. Their Adaptability skill will affect their survival chances. If they survive, they will return with loot. What they return with depends on the hut level and their Strength level.  
+Once they have their tools & items, they will activate the nether portal and travel to the nether.  The nether is dangerous! They will fight mobs they encounter there, and it is possible for them to die on the trip. Their Adaptability skill will affect their survival chances. If they survive, they will return with loot. What they return with depends on the hut level and their Strength level. The hut level determines what loot can be acquired, while the Strength level increases the chances of getting better loot and more per expedition.
+
+- **Level 1:**  blaze rod, ender pearl, ghast tear, gold ingot, gold nugget, gravel, gunpowder, leather, magma cream, nether quartz ore, netherrack, porkchop, rotten flesh, soul sand, soul_soil.
+- **Level 2:**  All items from previous levels, plus brown mushroom, crimson fungus, crimson nylium, crimson stem, glowstone, nether wart, red mushroom.
+- **Level 3:**  All items from previous levels, plus basalt, warped fungus, warped nylium, warped_stem.
+- **Level 4:**  All items from previous levels, plus blackstone, nether gold ore.
+- **Level 5:**  All items from previous levels, plus ancient debris.
 
 The Nether Miner can also craft lava buckets.
 


### PR DESCRIPTION
Both the Baker and the Bakery page include the potential breads that can be made as well as the hut level required to make each. This simply adds the loot table to the Nether Miner page from the Nether Mine page to have consistency between the two.
