### PR TITLE
Update happinessandsaturation.mdoc to fix happiness effect

### DIFF
--- a/src/content/wiki/systems/happinessandsaturation.mdoc
+++ b/src/content/wiki/systems/happinessandsaturation.mdoc
@@ -9,7 +9,7 @@ The citizens, however, will NOT die if their saturation goes down to 0, they wil
 
 ## Happiness System
 
-There is an **overall** colony happiness and an **individual** citizen happiness. Higher colony happiness increases the initial level and skills of new colonists. Higher citizen happiness increases the rate colonists gain Intelligence when studying at a {% building name="library" /%}.
+There is an **overall** colony happiness and an **individual** citizen happiness. Higher colony happiness increases the initial level and skills of new colonists. Higher citizen happiness increases the maximum possible Intelligence when studying at a {% building name="library" /%}.
 
 Overall colony happiness is 1-10 (initially set to 5). Happiness depends on three basic factors: **security, housing, and saturation**.
 


### PR DESCRIPTION
The happiness does not actually improve the rate at which intelligence is gained while studying, it only improves the maximum intelligence value. This change corrects it to say that.

![image](https://github.com/ldtteam/MinecoloniesWiki/assets/32230858/ef890983-7ca2-4bf5-b2a0-24142f2fce19)


