### PR TITLE
Update mystical site page to note stacking effects

### DIFF
--- a/src/content/wiki/buildings/mysticalsite.mdoc
+++ b/src/content/wiki/buildings/mysticalsite.mdoc
@@ -6,6 +6,8 @@ building: mysticalsite
 {% building_infobox %}
 The Mystical Site is a simple building that increase a colony's overall [happiness](/wiki/systems/happinessandsaturation) level. It has no worker and increases colonists' happiness just by existing.
 
+The happiness bonus does not stack - only the highest level of Mystical Site in the colony will provide a bonus. While there is no benefit to building multiple Mysical Sites, one is not prevented from doing so should they wish.
+
 The {% worker name="undertaker" /%} will visit the Mystical Site when there are no colonists to bury. Doing so will increase their Mana skill and, as such, their chance of resurrecting a killed citizen.
 {% /building_infobox %}
 


### PR DESCRIPTION
There was no mention of it on the page prior, but I figured it would be useful for people to know that while you can have multiple mystical sites, the effects of them do not stack.

