### PR TITLE
Maybe fixing a rendering issue?

### DIFF
--- a/src/content/recipes/minecolonies/blockhutmechanic.yaml
+++ b/src/content/recipes/minecolonies/blockhutmechanic.yaml
@@ -29,7 +29,7 @@ row2:
     - minecraft/dark_oak_planks
     - minecraft/crimson_planks
     - minecraft/warped_planks
-  item2: minecraft/redstoneblock
+  item2: minecraft/redstone_block
   item3:
     - minecraft/oak_planks
     - minecraft/spruce_planks


### PR DESCRIPTION
https://minecraft.fandom.com/wiki/Block_of_Redstone The Minecraft wiki says it's `redstone_block` not `redstoneblock` because I have no idea where images are anymore.

Closes #

## Changes proposed:
- 
- 
